### PR TITLE
feat(auth): add query-param auth type for Google AI Studio

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,8 +45,9 @@ type AuthConfig struct {
 }
 
 type ProviderAuth struct {
-	Type string `yaml:"type"` // "bearer", "x-api-key", "none"
-	Key  string `yaml:"key"`
+	Type      string `yaml:"type"`       // "bearer", "x-api-key", "query-param", "none"
+	Key       string `yaml:"key"`
+	ParamName string `yaml:"param_name"` // for query-param auth, e.g. "key"
 }
 
 type HealthCheckConfig struct {
@@ -120,9 +121,10 @@ func applyDefaults(cfg *Config) {
 }
 
 var validAuthTypes = map[string]bool{
-	"bearer":    true,
-	"x-api-key": true,
-	"none":      true,
+	"bearer":      true,
+	"x-api-key":   true,
+	"query-param": true,
+	"none":        true,
 }
 
 func validate(cfg *Config) error {
@@ -147,7 +149,10 @@ func validate(cfg *Config) error {
 			return fmt.Errorf("providers[%d] %q: upstream is required", i, p.Name)
 		}
 		if !validAuthTypes[p.Auth.Type] {
-			return fmt.Errorf("providers[%d] %q: invalid auth type %q (valid: bearer, x-api-key, none)", i, p.Name, p.Auth.Type)
+			return fmt.Errorf("providers[%d] %q: invalid auth type %q (valid: bearer, x-api-key, query-param, none)", i, p.Name, p.Auth.Type)
+		}
+		if p.Auth.Type == "query-param" && p.Auth.ParamName == "" {
+			return fmt.Errorf("providers[%d] %q: auth type query-param requires param_name", i, p.Name)
 		}
 		providerNames[p.Name] = true
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -298,3 +298,55 @@ providers:
 		t.Errorf("default health_check timeout = %v, want 5s", hc.Timeout)
 	}
 }
+
+func TestValidate_QueryParamAuth(t *testing.T) {
+	yaml := `
+server:
+  port: 8080
+auth:
+  tokens:
+    - name: test
+      token: yai_xxx
+providers:
+  - name: gemini
+    upstream: https://generativelanguage.googleapis.com
+    auth:
+      type: query-param
+      key: AIzaSyXXXXXXXXXXXXXXXXX
+      param_name: key
+`
+	cfg, err := Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Providers[0].Auth.Type != "query-param" {
+		t.Errorf("auth type = %q, want query-param", cfg.Providers[0].Auth.Type)
+	}
+	if cfg.Providers[0].Auth.ParamName != "key" {
+		t.Errorf("param_name = %q, want key", cfg.Providers[0].Auth.ParamName)
+	}
+}
+
+func TestValidate_QueryParamMissingParamName(t *testing.T) {
+	yaml := `
+server:
+  port: 8080
+auth:
+  tokens:
+    - name: test
+      token: yai_xxx
+providers:
+  - name: gemini
+    upstream: https://generativelanguage.googleapis.com
+    auth:
+      type: query-param
+      key: AIzaSyXXXXXXXXXXXXXXXXX
+`
+	_, err := Parse(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error for query-param without param_name")
+	}
+	if !strings.Contains(err.Error(), "param_name") {
+		t.Errorf("error = %q, want mention of param_name", err.Error())
+	}
+}

--- a/internal/proxy/key_injection_test.go
+++ b/internal/proxy/key_injection_test.go
@@ -196,3 +196,119 @@ func TestKeyInjection_ExtraHeaders(t *testing.T) {
 		t.Errorf("Anthropic-Beta = %q, want %q", got, "interleaved-thinking-2025-05-14")
 	}
 }
+
+// queryCapture records the query parameters received by the upstream.
+type queryCapture struct {
+	mu     sync.Mutex
+	Query  map[string]string
+	Server *httptest.Server
+}
+
+func newQueryCaptureServer() *queryCapture {
+	qc := &queryCapture{
+		Query: make(map[string]string),
+	}
+	qc.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		qc.mu.Lock()
+		for k, v := range r.URL.Query() {
+			if len(v) > 0 {
+				qc.Query[k] = v[0]
+			}
+		}
+		qc.mu.Unlock()
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	return qc
+}
+
+func TestKeyInjection_QueryParam(t *testing.T) {
+	qc := newQueryCaptureServer()
+	defer qc.Server.Close()
+
+	providers := []config.ProviderConfig{
+		{
+			Name:     "gemini",
+			Upstream: qc.Server.URL,
+			Auth:     config.ProviderAuth{Type: "query-param", Key: "AIzaSyFAKEKEY", ParamName: "key"},
+		},
+	}
+
+	p := New(providers)
+	req := httptest.NewRequest("POST", "/proxy/gemini/v1beta/models/gemini-2.5-flash:generateContent", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer yai_xxx")
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	qc.mu.Lock()
+	defer qc.mu.Unlock()
+
+	if got, ok := qc.Query["key"]; !ok || got != "AIzaSyFAKEKEY" {
+		t.Errorf("query param key = %q, want %q", got, "AIzaSyFAKEKEY")
+	}
+}
+
+func TestKeyInjection_QueryParamStripsAuthHeader(t *testing.T) {
+	hc := newHeaderCaptureServer()
+	defer hc.Server.Close()
+
+	providers := []config.ProviderConfig{
+		{
+			Name:     "gemini",
+			Upstream: hc.Server.URL,
+			Auth:     config.ProviderAuth{Type: "query-param", Key: "AIzaSyFAKEKEY", ParamName: "key"},
+		},
+	}
+
+	p := New(providers)
+	req := httptest.NewRequest("POST", "/proxy/gemini/v1beta/models/gemini-2.5-flash:generateContent", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer yai_xxx")
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	// Should NOT forward any auth headers
+	if hc.Has("Authorization") {
+		t.Errorf("Authorization header should be stripped for query-param auth, got %q", hc.Get("Authorization"))
+	}
+}
+
+func TestKeyInjection_QueryParamPreservesExistingParams(t *testing.T) {
+	qc := newQueryCaptureServer()
+	defer qc.Server.Close()
+
+	providers := []config.ProviderConfig{
+		{
+			Name:     "gemini",
+			Upstream: qc.Server.URL,
+			Auth:     config.ProviderAuth{Type: "query-param", Key: "AIzaSyFAKEKEY", ParamName: "key"},
+		},
+	}
+
+	p := New(providers)
+	// Request with existing query param
+	req := httptest.NewRequest("POST", "/proxy/gemini/v1beta/models/gemini-2.5-flash:generateContent?alt=sse", strings.NewReader("{}"))
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	qc.mu.Lock()
+	defer qc.mu.Unlock()
+
+	if got := qc.Query["key"]; got != "AIzaSyFAKEKEY" {
+		t.Errorf("query param key = %q, want %q", got, "AIzaSyFAKEKEY")
+	}
+	if got := qc.Query["alt"]; got != "sse" {
+		t.Errorf("query param alt = %q, want %q (should preserve existing params)", got, "sse")
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -61,6 +61,10 @@ func (pp *providerProxy) director(req *http.Request) {
 		req.Header.Set("Authorization", "Bearer "+pp.config.Auth.Key)
 	case "x-api-key":
 		req.Header.Set("X-Api-Key", pp.config.Auth.Key)
+	case "query-param":
+		q := req.URL.Query()
+		q.Set(pp.config.Auth.ParamName, pp.config.Auth.Key)
+		req.URL.RawQuery = q.Encode()
 	case "none":
 		// no auth header
 	}

--- a/yai.example.yaml
+++ b/yai.example.yaml
@@ -45,6 +45,18 @@ providers:
       interval: 10s
       timeout: 2s
 
+  - name: gemini
+    upstream: https://generativelanguage.googleapis.com
+    auth:
+      type: query-param
+      key: AIzaSy-change-me
+      param_name: key
+    health_check:
+      method: GET
+      path: /v1beta/models
+      interval: 30s
+      timeout: 5s
+
 fallback:
   groups:
     - name: openai-compat


### PR DESCRIPTION
## Summary

Add `query-param` auth type that injects API key as a URL query parameter. Covers **Google AI Studio (Gemini)** which uses `?key=AIzaSy...` authentication.

## Config

```yaml
- name: gemini
  upstream: https://generativelanguage.googleapis.com
  auth:
    type: query-param
    key: AIzaSy-xxx
    param_name: key
```

## Changes

- `config`: add `ParamName` field to `ProviderAuth`, validate `param_name` is required for `query-param` type
- `proxy`: inject key as query param in director, preserve existing query params
- `yai.example.yaml`: add Gemini example

## Tests (5 new, 55 total)

| Test | What it verifies |
|------|-----------------|
| `TestValidate_QueryParamAuth` | Config parses correctly |
| `TestValidate_QueryParamMissingParamName` | Rejects missing param_name |
| `TestKeyInjection_QueryParam` | Key appears in upstream URL query |
| `TestKeyInjection_QueryParamStripsAuthHeader` | Client auth header stripped |
| `TestKeyInjection_QueryParamPreservesExistingParams` | Existing `?alt=sse` preserved |

Part 1 of auth type expansion: query-param → oauth2 → aws-sigv4