### PR TITLE
feat: environment variable expansion in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,42 @@ curl http://localhost:8080/proxy/deepseek/v1/chat/completions \
 
 See [yai.example.yaml](yai.example.yaml) for a full example with all auth types.
 
+### Environment Variable Expansion
+
+Keep secrets out of config files using `${VAR}` or `${VAR:-default}`:
+
+```yaml
+auth:
+  tokens:
+    - name: main
+      token: ${YAI_AUTH_TOKEN}
+
+providers:
+  - name: anthropic
+    auth:
+      type: x-api-key
+      key: ${YAI_ANTHROPIC_KEY}
+```
+
+```bash
+export YAI_AUTH_TOKEN=yai_xxx
+export YAI_ANTHROPIC_KEY=sk-ant-xxx
+./yai -config yai.yaml
+```
+
+Or with systemd:
+
+```ini
+# /etc/yai/env
+YAI_AUTH_TOKEN=yai_xxx
+YAI_ANTHROPIC_KEY=sk-ant-xxx
+
+# /etc/systemd/system/yai.service
+[Service]
+EnvironmentFile=/etc/yai/env
+ExecStart=/usr/local/bin/yai -config /etc/yai/yai.yaml
+```
+
 ## Architecture
 
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"io"
+	"os"
+	"regexp"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -95,10 +97,17 @@ type Config struct {
 }
 
 // Parse reads YAML from r and returns a validated Config.
+// Environment variables in the form ${VAR} or ${VAR:-default} are expanded
+// before parsing.
 func Parse(r io.Reader) (*Config, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	expanded := expandEnv(string(raw))
+
 	var cfg Config
-	dec := yaml.NewDecoder(r)
-	if err := dec.Decode(&cfg); err != nil {
+	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
 		return nil, fmt.Errorf("yaml decode: %w", err)
 	}
 	applyDefaults(&cfg)
@@ -106,6 +115,26 @@ func Parse(r io.Reader) (*Config, error) {
 		return nil, err
 	}
 	return &cfg, nil
+}
+
+// envPattern matches ${VAR} and ${VAR:-default}.
+var envPattern = regexp.MustCompile(`\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?\}`)
+
+// expandEnv replaces ${VAR} with os.Getenv("VAR").
+// ${VAR:-default} uses "default" if VAR is unset or empty.
+func expandEnv(s string) string {
+	return envPattern.ReplaceAllStringFunc(s, func(match string) string {
+		parts := envPattern.FindStringSubmatch(match)
+		if parts == nil {
+			return match
+		}
+		name := parts[1]
+		fallback := parts[2]
+		if val := os.Getenv(name); val != "" {
+			return val
+		}
+		return fallback
+	})
 }
 
 func applyDefaults(cfg *Config) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -657,3 +657,139 @@ providers:
 		t.Errorf("error = %q", err.Error())
 	}
 }
+
+func TestExpandEnvSimple(t *testing.T) {
+	t.Setenv("YAI_TEST_KEY", "sk-secret-123")
+
+	yaml := `
+server:
+  port: 8080
+auth:
+  tokens:
+    - name: test
+      token: test-token
+providers:
+  - name: anthropic
+    upstream: https://api.anthropic.com
+    auth:
+      type: x-api-key
+      key: ${YAI_TEST_KEY}
+    health_check:
+      path: /v1/models
+`
+	cfg, err := Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if cfg.Providers[0].Auth.Key != "sk-secret-123" {
+		t.Errorf("key = %q, want %q", cfg.Providers[0].Auth.Key, "sk-secret-123")
+	}
+}
+
+func TestExpandEnvWithDefault(t *testing.T) {
+	// Make sure env var is NOT set
+	t.Setenv("YAI_UNSET_VAR_12345", "")
+
+	yaml := `
+server:
+  port: 8080
+auth:
+  tokens:
+    - name: test
+      token: test-token
+providers:
+  - name: anthropic
+    upstream: https://api.anthropic.com
+    auth:
+      type: x-api-key
+      key: ${YAI_UNSET_VAR_12345:-fallback-key}
+    health_check:
+      path: /v1/models
+`
+	cfg, err := Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if cfg.Providers[0].Auth.Key != "fallback-key" {
+		t.Errorf("key = %q, want %q", cfg.Providers[0].Auth.Key, "fallback-key")
+	}
+}
+
+func TestExpandEnvOverridesDefault(t *testing.T) {
+	t.Setenv("YAI_REAL_KEY", "real-value")
+
+	yaml := `
+server:
+  port: 8080
+auth:
+  tokens:
+    - name: test
+      token: test-token
+providers:
+  - name: anthropic
+    upstream: https://api.anthropic.com
+    auth:
+      type: x-api-key
+      key: ${YAI_REAL_KEY:-fallback}
+    health_check:
+      path: /v1/models
+`
+	cfg, err := Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if cfg.Providers[0].Auth.Key != "real-value" {
+		t.Errorf("key = %q, want %q", cfg.Providers[0].Auth.Key, "real-value")
+	}
+}
+
+func TestExpandEnvMultipleVars(t *testing.T) {
+	t.Setenv("YAI_TOKEN", "my-token")
+	t.Setenv("YAI_ANT_KEY", "sk-ant-xxx")
+
+	yaml := `
+server:
+  port: 8080
+auth:
+  tokens:
+    - name: test
+      token: ${YAI_TOKEN}
+providers:
+  - name: anthropic
+    upstream: https://api.anthropic.com
+    auth:
+      type: x-api-key
+      key: ${YAI_ANT_KEY}
+    health_check:
+      path: /v1/models
+`
+	cfg, err := Parse(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if cfg.Auth.Tokens[0].Token != "my-token" {
+		t.Errorf("token = %q, want %q", cfg.Auth.Tokens[0].Token, "my-token")
+	}
+	if cfg.Providers[0].Auth.Key != "sk-ant-xxx" {
+		t.Errorf("key = %q, want %q", cfg.Providers[0].Auth.Key, "sk-ant-xxx")
+	}
+}
+
+func TestExpandEnvUnsetNoDefault(t *testing.T) {
+	// ${UNSET_VAR} with no default should resolve to empty string
+	t.Setenv("YAI_MISSING_VAR_99999", "")
+
+	result := expandEnv("prefix-${YAI_MISSING_VAR_99999}-suffix")
+	if result != "prefix--suffix" {
+		t.Errorf("got %q, want %q", result, "prefix--suffix")
+	}
+}
+
+func TestExpandEnvNoVars(t *testing.T) {
+	// Plain text should pass through unchanged
+	input := "just a regular string with no vars"
+	result := expandEnv(input)
+	if result != input {
+		t.Errorf("got %q, want %q", result, input)
+	}
+}

--- a/yai.example.yaml
+++ b/yai.example.yaml
@@ -1,5 +1,13 @@
 # yai configuration
 # Copy this file to yai.yaml and fill in your real keys.
+#
+# Environment variable expansion:
+#   ${VAR}            — replaced with the value of $VAR (empty string if unset)
+#   ${VAR:-default}   — replaced with $VAR, or "default" if unset/empty
+#
+# Example: keep secrets out of this file
+#   key: ${YAI_ANTHROPIC_KEY}
+# Then: export YAI_ANTHROPIC_KEY=sk-ant-xxx && ./yai
 
 server:
   host: 0.0.0.0
@@ -8,14 +16,14 @@ server:
 auth:
   tokens:
     - name: cicada-main
-      token: yai_change_me
+      token: ${YAI_AUTH_TOKEN:-changeme}
 
 providers:
   - name: anthropic
     upstream: https://api.anthropic.com
     auth:
       type: x-api-key
-      key: sk-ant-api03-change-me
+      key: ${YAI_ANTHROPIC_KEY}
     extra_headers:
       anthropic-version: "2023-06-01"
     health_check:
@@ -28,7 +36,7 @@ providers:
     upstream: https://api.deepseek.com
     auth:
       type: bearer
-      key: sk-deepseek-change-me
+      key: ${YAI_DEEPSEEK_KEY}
     health_check:
       method: GET
       path: /v1/models
@@ -49,7 +57,7 @@ providers:
     upstream: https://generativelanguage.googleapis.com
     auth:
       type: query-param
-      key: AIzaSy-change-me
+      key: ${YAI_GEMINI_KEY}
       param_name: key
     health_check:
       method: GET
@@ -65,8 +73,8 @@ providers:
   #   auth:
   #     type: oauth2-client-credentials
   #     token_url: https://aip.baidubce.com/oauth/2.0/token
-  #     client_id: your-api-key
-  #     client_secret: your-secret-key
+  #     client_id: ${YAI_BAIDU_CLIENT_ID}
+  #     client_secret: ${YAI_BAIDU_CLIENT_SECRET}
   #   health_check:
   #     method: GET
   #     path: /rpc/2.0/ai_custom/v1/wenxinworkshop/chat/completions
@@ -92,9 +100,9 @@ providers:
   #   upstream: https://your-instance.openai.azure.com
   #   auth:
   #     type: oauth2-azure-ad
-  #     tenant_id: 00001111-aaaa-2222-bbbb-3333cccc4444
-  #     client_id: your-app-client-id
-  #     client_secret: your-app-client-secret
+  #     tenant_id: ${YAI_AZURE_TENANT_ID}
+  #     client_id: ${YAI_AZURE_CLIENT_ID}
+  #     client_secret: ${YAI_AZURE_CLIENT_SECRET}
   #     # scopes:  # optional, defaults to https://cognitiveservices.azure.com/.default
   #     #   - https://cognitiveservices.azure.com/.default
   #   health_check:


### PR DESCRIPTION
## What

Support `${VAR}` and `${VAR:-default}` in `yai.yaml` so secrets stay out of config files.

```yaml
providers:
  - name: anthropic
    auth:
      type: x-api-key
      key: ${YAI_ANTHROPIC_KEY}
```

## How

Regex-based expansion runs before YAML parsing — no new dependencies. Works with any string value in the config.

## Changes

- `config.go`: `expandEnv()` function, `Parse()` calls it before `yaml.Unmarshal`
- 7 new tests (simple, default value, override, multiple vars, unset, passthrough)
- `yai.example.yaml`: all secrets now use `${YAI_*}` placeholders
- `README.md`: env var + systemd EnvironmentFile docs