### PR TITLE
feat: config hot-reload on SIGHUP

### DIFF
--- a/cmd/yai/main.go
+++ b/cmd/yai/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -12,12 +11,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/yahaha-ai/yai/internal/auth"
 	"github.com/yahaha-ai/yai/internal/config"
-	"github.com/yahaha-ai/yai/internal/fallback"
-	"github.com/yahaha-ai/yai/internal/health"
-	"github.com/yahaha-ai/yai/internal/proxy"
-	"github.com/yahaha-ai/yai/internal/ratelimit"
+	"github.com/yahaha-ai/yai/internal/server"
 )
 
 func main() {
@@ -35,40 +30,12 @@ func main() {
 		log.Fatalf("failed to parse config: %v", err)
 	}
 
-	// Build token map for auth (with optional rate limiters)
-	tokenMap := make(map[string]auth.TokenInfo)
-	for _, tok := range cfg.Auth.Tokens {
-		info := auth.TokenInfo{Name: tok.Name}
-		if tok.RateLimit != "" {
-			limit, err := ratelimit.ParseLimit(tok.RateLimit)
-			if err != nil {
-				log.Fatalf("auth token %q: invalid rate_limit: %v", tok.Name, err)
-			}
-			info.Limiter = ratelimit.NewLimiter(limit)
-		}
-		tokenMap[tok.Token] = info
+	// Initialize server with hot-reloadable components
+	srv, err := server.New(*configPath, cfg)
+	if err != nil {
+		log.Fatalf("failed to initialize server: %v", err)
 	}
-
-	// Initialize components
-	p := proxy.New(cfg.Providers)
-	checker := health.New(cfg.Providers)
-	checker.Start()
-	defer checker.Stop()
-
-	handler := fallback.New(p, checker, cfg.Fallback.Groups)
-
-	// Build router
-	mux := http.NewServeMux()
-
-	// Health endpoint (no auth)
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		statuses := checker.AllStatuses()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(statuses)
-	})
-
-	// Proxy routes (auth required)
-	mux.Handle("/proxy/", auth.Middleware(tokenMap, handler))
+	defer srv.Stop()
 
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
 	log.Printf("yai listening on %s", addr)
@@ -76,33 +43,47 @@ func main() {
 	log.Printf("  fallback groups: %d", len(cfg.Fallback.Groups))
 	log.Printf("  auth tokens: %d", len(cfg.Auth.Tokens))
 
-	server := &http.Server{
+	httpServer := &http.Server{
 		Addr:    addr,
-		Handler: mux,
+		Handler: srv.Handler(),
 	}
 
-	// Graceful shutdown on SIGINT/SIGTERM
+	// Signal handling: SIGHUP for reload, SIGINT/SIGTERM for shutdown
 	done := make(chan struct{})
 	go func() {
 		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-		sig := <-sigCh
-		log.Printf("received %v, shutting down gracefully...", sig)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
-		timeout := 30 * time.Second
-		if cfg.Server.ShutdownTimeout.Duration > 0 {
-			timeout = cfg.Server.ShutdownTimeout.Duration
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
+		for sig := range sigCh {
+			switch sig {
+			case syscall.SIGHUP:
+				log.Printf("received SIGHUP, reloading config...")
+				if err := srv.Reload(); err != nil {
+					log.Printf("config reload FAILED: %v (keeping previous config)", err)
+				} else {
+					log.Printf("config reloaded successfully")
+				}
 
-		if err := server.Shutdown(ctx); err != nil {
-			log.Printf("shutdown error: %v", err)
+			case syscall.SIGINT, syscall.SIGTERM:
+				log.Printf("received %v, shutting down gracefully...", sig)
+
+				timeout := 30 * time.Second
+				if cfg.Server.ShutdownTimeout.Duration > 0 {
+					timeout = cfg.Server.ShutdownTimeout.Duration
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+
+				if err := httpServer.Shutdown(ctx); err != nil {
+					log.Printf("shutdown error: %v", err)
+				}
+				close(done)
+				return
+			}
 		}
-		close(done)
 	}()
 
-	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+	if err := httpServer.ListenAndServe(); err != http.ErrServerClosed {
 		log.Fatalf("server error: %v", err)
 	}
 	<-done

--- a/cmd/yai/main_test.go
+++ b/cmd/yai/main_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/yahaha-ai/yai/internal/fallback"
 	"github.com/yahaha-ai/yai/internal/health"
 	"github.com/yahaha-ai/yai/internal/proxy"
+	"github.com/yahaha-ai/yai/internal/server"
 )
 
 // buildServer creates a full yai server with mock upstreams for integration testing.
@@ -43,6 +45,10 @@ func buildServer(t *testing.T) (*httptest.Server, func()) {
 				Interval: config.Duration{Duration: 50 * time.Millisecond},
 				Timeout:  config.Duration{Duration: 1 * time.Second},
 			},
+			Timeout: config.TimeoutConfig{
+				Connect: config.Duration{Duration: 10 * time.Second},
+				Read:    config.Duration{Duration: 300 * time.Second},
+			},
 		},
 	}
 
@@ -65,15 +71,15 @@ func buildServer(t *testing.T) (*httptest.Server, func()) {
 	})
 	mux.Handle("/proxy/", auth.Middleware(tokenMap, handler))
 
-	server := httptest.NewServer(mux)
+	srv := httptest.NewServer(mux)
 
 	cleanup := func() {
 		checker.Stop()
 		upstream.Close()
-		server.Close()
+		srv.Close()
 	}
 
-	return server, cleanup
+	return srv, cleanup
 }
 
 func TestIntegration_HealthEndpoint(t *testing.T) {
@@ -205,6 +211,10 @@ func TestIntegration_SSEStreaming(t *testing.T) {
 				Interval: config.Duration{Duration: 50 * time.Millisecond},
 				Timeout:  config.Duration{Duration: 1 * time.Second},
 			},
+			Timeout: config.TimeoutConfig{
+				Connect: config.Duration{Duration: 10 * time.Second},
+				Read:    config.Duration{Duration: 300 * time.Second},
+			},
 		},
 	}
 	tokenMap := map[string]auth.TokenInfo{"yai_test": {Name: "test"}}
@@ -218,10 +228,10 @@ func TestIntegration_SSEStreaming(t *testing.T) {
 	handler := fallback.New(p, checker, nil)
 	mux := http.NewServeMux()
 	mux.Handle("/proxy/", auth.Middleware(tokenMap, handler))
-	server := httptest.NewServer(mux)
-	defer server.Close()
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
 
-	req, _ := http.NewRequest("POST", server.URL+"/proxy/sse-mock/v1/messages", strings.NewReader("{}"))
+	req, _ := http.NewRequest("POST", srv.URL+"/proxy/sse-mock/v1/messages", strings.NewReader("{}"))
 	req.Header.Set("Authorization", "Bearer yai_test")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -240,5 +250,214 @@ func TestIntegration_SSEStreaming(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), "message_start") {
 		t.Error("response should contain SSE events")
+	}
+}
+
+func TestIntegration_HotReload(t *testing.T) {
+	// Create mock upstream
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+	}))
+	defer upstream.Close()
+
+	// Write initial config to temp file
+	initialConfig := fmt.Sprintf(`
+server:
+  host: 127.0.0.1
+  port: 0
+auth:
+  tokens:
+    - name: test
+      token: yai_initial
+providers:
+  - name: mock
+    upstream: %s
+    auth:
+      type: none
+    health_check:
+      interval: 50ms
+      timeout: 1s
+`, upstream.URL)
+
+	tmpFile, err := os.CreateTemp("", "yai-test-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(initialConfig); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	// Parse initial config
+	f, _ := os.Open(tmpFile.Name())
+	cfg, err := config.Parse(f)
+	f.Close()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	// Create server
+	srv, err := server.New(tmpFile.Name(), cfg)
+	if err != nil {
+		t.Fatalf("server init: %v", err)
+	}
+	defer srv.Stop()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Initial token works
+	req, _ := http.NewRequest("POST", ts.URL+"/proxy/mock/test", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer yai_initial")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("initial request: status = %d, want 200", resp.StatusCode)
+	}
+
+	// Write updated config with a different token
+	updatedConfig := fmt.Sprintf(`
+server:
+  host: 127.0.0.1
+  port: 0
+auth:
+  tokens:
+    - name: test
+      token: yai_reloaded
+providers:
+  - name: mock
+    upstream: %s
+    auth:
+      type: none
+    health_check:
+      interval: 50ms
+      timeout: 1s
+`, upstream.URL)
+
+	if err := os.WriteFile(tmpFile.Name(), []byte(updatedConfig), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger reload
+	if err := srv.Reload(); err != nil {
+		t.Fatalf("reload failed: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Old token should now fail
+	req, _ = http.NewRequest("POST", ts.URL+"/proxy/mock/test", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer yai_initial")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Errorf("old token after reload: status = %d, want 401", resp.StatusCode)
+	}
+
+	// New token should work
+	req, _ = http.NewRequest("POST", ts.URL+"/proxy/mock/test", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer yai_reloaded")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("new token after reload: status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestIntegration_HotReloadInvalidConfig(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"ok": "true"})
+	}))
+	defer upstream.Close()
+
+	initialConfig := fmt.Sprintf(`
+server:
+  host: 127.0.0.1
+  port: 0
+auth:
+  tokens:
+    - name: test
+      token: yai_ok
+providers:
+  - name: mock
+    upstream: %s
+    auth:
+      type: none
+    health_check:
+      interval: 50ms
+      timeout: 1s
+`, upstream.URL)
+
+	tmpFile, err := os.CreateTemp("", "yai-test-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(initialConfig); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	f, _ := os.Open(tmpFile.Name())
+	cfg, err := config.Parse(f)
+	f.Close()
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	srv, err := server.New(tmpFile.Name(), cfg)
+	if err != nil {
+		t.Fatalf("server init: %v", err)
+	}
+	defer srv.Stop()
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Write invalid config (no tokens)
+	if err := os.WriteFile(tmpFile.Name(), []byte(`
+server:
+  port: 0
+auth:
+  tokens: []
+providers: []
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reload should fail
+	err = srv.Reload()
+	if err == nil {
+		t.Fatal("expected reload error for invalid config")
+	}
+
+	// Original token should still work (old config preserved)
+	req, _ := http.NewRequest("POST", ts.URL+"/proxy/mock/test", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer yai_ok")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("after failed reload: status = %d, want 200 (old config should be preserved)", resp.StatusCode)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,127 @@
+// Package server provides the yai HTTP server with config hot-reload support.
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/yahaha-ai/yai/internal/auth"
+	"github.com/yahaha-ai/yai/internal/config"
+	"github.com/yahaha-ai/yai/internal/fallback"
+	"github.com/yahaha-ai/yai/internal/health"
+	"github.com/yahaha-ai/yai/internal/proxy"
+	"github.com/yahaha-ai/yai/internal/ratelimit"
+)
+
+// Server wraps the HTTP mux with hot-reloadable components.
+type Server struct {
+	configPath string
+	handler    atomic.Value // stores *liveHandler
+	checker    *health.Checker
+	mu         sync.Mutex // serializes reloads
+}
+
+// liveHandler holds a snapshot of all hot-reloadable components.
+type liveHandler struct {
+	authHandler http.Handler
+	checker     *health.Checker
+}
+
+// New creates a Server. The initial config must be valid (caller handles errors).
+func New(configPath string, cfg *config.Config) (*Server, error) {
+	s := &Server{configPath: configPath}
+	if err := s.load(cfg); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// load builds components from config and stores them atomically.
+func (s *Server) load(cfg *config.Config) error {
+	tokenMap := buildTokenMap(cfg)
+	p := proxy.New(cfg.Providers)
+
+	// Stop old health checker if any
+	if s.checker != nil {
+		s.checker.Stop()
+	}
+	checker := health.New(cfg.Providers)
+	checker.Start()
+	s.checker = checker
+
+	handler := fallback.New(p, checker, cfg.Fallback.Groups)
+	authHandler := auth.Middleware(tokenMap, handler)
+
+	s.handler.Store(&liveHandler{
+		authHandler: authHandler,
+		checker:     checker,
+	})
+	return nil
+}
+
+// Reload re-reads the config file and swaps components atomically.
+// Returns an error if the new config is invalid (old config stays active).
+func (s *Server) Reload() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	f, err := os.Open(s.configPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	cfg, err := config.Parse(f)
+	if err != nil {
+		return err
+	}
+
+	return s.load(cfg)
+}
+
+// Handler returns an http.Handler that routes to the live components.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		live := s.handler.Load().(*liveHandler)
+		statuses := live.checker.AllStatuses()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(statuses)
+	})
+
+	mux.HandleFunc("/proxy/", func(w http.ResponseWriter, r *http.Request) {
+		live := s.handler.Load().(*liveHandler)
+		live.authHandler.ServeHTTP(w, r)
+	})
+
+	return mux
+}
+
+// Stop cleans up background resources (health checker).
+func (s *Server) Stop() {
+	if s.checker != nil {
+		s.checker.Stop()
+	}
+}
+
+func buildTokenMap(cfg *config.Config) map[string]auth.TokenInfo {
+	tokenMap := make(map[string]auth.TokenInfo)
+	for _, tok := range cfg.Auth.Tokens {
+		info := auth.TokenInfo{Name: tok.Name}
+		if tok.RateLimit != "" {
+			limit, err := ratelimit.ParseLimit(tok.RateLimit)
+			if err != nil {
+				log.Printf("WARN: auth token %q: invalid rate_limit: %v", tok.Name, err)
+				continue
+			}
+			info.Limiter = ratelimit.NewLimiter(limit)
+		}
+		tokenMap[tok.Token] = info
+	}
+	return tokenMap
+}


### PR DESCRIPTION
Closes #10

## Changes
- New `internal/server` package with atomic handler swapping via `sync/atomic.Value`
- `SIGHUP` → re-reads config, re-expands env vars, rebuilds providers/auth/fallback
- Failed reload keeps old config active (fail-safe)
- In-flight requests on existing connections are unaffected during reload

## Usage
```bash
# Edit yai.yaml (add provider, change token, etc.)
kill -HUP $(pidof yai)
# Logs: 'config reloaded successfully' or 'config reload FAILED: ... (keeping previous config)'
```

## Tests
- `TestIntegration_HotReload`: verifies token swap takes effect after reload
- `TestIntegration_HotReloadInvalidConfig`: verifies old config preserved on bad reload