### PR TITLE
ops: systemd unit file with hardening

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,69 @@
+# systemd Deployment
+
+## Install
+
+```bash
+# Copy binary
+sudo cp yai /usr/local/bin/yai
+sudo chmod +x /usr/local/bin/yai
+
+# Create user
+sudo useradd -r -s /usr/sbin/nologin yai
+
+# Create config dir
+sudo mkdir -p /etc/yai
+sudo cp yai.yaml /etc/yai/yai.yaml
+sudo cp deploy/env.example /etc/yai/env
+sudo chown -R yai:yai /etc/yai
+sudo chmod 600 /etc/yai/env /etc/yai/yai.yaml
+
+# Install service
+sudo cp deploy/yai.service /etc/systemd/system/yai.service
+sudo systemctl daemon-reload
+sudo systemctl enable yai
+sudo systemctl start yai
+```
+
+## Operations
+
+```bash
+# Check status
+sudo systemctl status yai
+sudo journalctl -u yai -f
+
+# Reload config (no downtime — sends SIGHUP)
+sudo systemctl reload yai
+
+# Restart
+sudo systemctl restart yai
+
+# Update binary
+sudo systemctl stop yai
+sudo cp yai-new /usr/local/bin/yai
+sudo systemctl start yai
+```
+
+## Environment Variables
+
+Edit `/etc/yai/env` with your API keys:
+
+```
+YAI_ANTHROPIC_KEY=sk-ant-api03-xxxxx
+YAI_DEEPSEEK_KEY=sk-xxxxx
+```
+
+Then reference them in `yai.yaml`:
+
+```yaml
+providers:
+  - name: anthropic
+    auth:
+      type: x-api-key
+      key: ${YAI_ANTHROPIC_KEY}
+```
+
+After editing env, reload the service:
+
+```bash
+sudo systemctl restart yai   # env changes require restart, not just reload
+```

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -1,0 +1,7 @@
+# /etc/yai/env — environment variables for yai systemd service
+# Secrets referenced via ${VAR} in yai.yaml are loaded from here.
+#
+# Example:
+# YAI_ANTHROPIC_KEY=sk-ant-api03-xxxxx
+# YAI_DEEPSEEK_KEY=sk-xxxxx
+# YAI_GEMINI_KEY=AIzaSyxxxxx

--- a/deploy/yai.service
+++ b/deploy/yai.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=yai — unified LLM API proxy
+Documentation=https://github.com/yahaha-ai/yai
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=yai
+Group=yai
+ExecStart=/usr/local/bin/yai -config /etc/yai/yai.yaml
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=-/etc/yai/env
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=yai
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ReadOnlyPaths=/etc/yai
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RestrictRealtime=true
+MemoryDenyWriteExecute=true
+LockPersonality=true
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #7

## Files
- `deploy/yai.service` — systemd unit with security hardening
- `deploy/env.example` — template for secrets
- `deploy/README.md` — install and operation instructions

## Features
- `ExecReload=/bin/kill -HUP $MAINPID` — ties into #10 hot-reload
- Full hardening: NoNewPrivileges, ProtectSystem=strict, PrivateTmp, etc.
- Restart on failure with 5s backoff