### PR TITLE
ops: goreleaser + GitHub Release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./... -race -count=1 -timeout 120s
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,51 @@
+version: 2
+
+project_name: yai
+
+builds:
+  - id: yai
+    main: ./cmd/yai
+    binary: yai
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - yai.example.yaml
+      - deploy/*
+      - README.md
+      - LICENSE*
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "Merge pull request"
+
+release:
+  github:
+    owner: yahaha-ai
+    name: yai
+  draft: false
+  prerelease: auto

--- a/cmd/yai/main.go
+++ b/cmd/yai/main.go
@@ -15,9 +15,22 @@ import (
 	"github.com/yahaha-ai/yai/internal/server"
 )
 
+// Set by goreleaser ldflags
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
 	configPath := flag.String("config", "yai.yaml", "path to config file")
+	showVersion := flag.Bool("version", false, "print version and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("yai %s (commit: %s, built: %s)\n", version, commit, date)
+		os.Exit(0)
+	}
 
 	// Load config
 	f, err := os.Open(*configPath)


### PR DESCRIPTION
Closes #9

## Files
- `.goreleaser.yml` — builds linux/darwin × amd64/arm64 with version ldflags
- `.github/workflows/release.yml` — triggers on `v*` tag push, runs tests then goreleaser
- `cmd/yai/main.go` — added `-version` flag

## Usage
```bash
# Create a release
git tag v0.1.0
git push origin v0.1.0
# GitHub Actions builds binaries and creates a release
```